### PR TITLE
Switching from openAI to google gemini for free quota

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,16 +6,16 @@
 # The generated SQL query is then run on our database
 
 from typing import Union
-
+import sys
 from fastapi import FastAPI
 from pydantic import BaseModel
 from fastapi import HTTPException
 import psycopg2
 from nl2sql import nl2sql_chain  # Import your NL2SQL chain
-from config import OPENAI_API_KEY
 import os
 import uvicorn
 
+sys.path.insert(0, 'RAG_Pipeline')
 app = FastAPI()
 
 # Pydantic model for input validation
@@ -37,7 +37,7 @@ async def query_db(request: QueryRequest):
     # Generate SQL query from the natural language input
     try:
         sql_query = nl2sql_chain.invoke(request.question)
-        print(sql_query)
+        print("SQL QUERY Testing: ",sql_query)
     except Exception as e:
         raise HTTPException(status_code=500, detail="Error generating SQL query.")
     

--- a/nl2sql.py
+++ b/nl2sql.py
@@ -1,6 +1,8 @@
 import os
 from config import OPENAI_API_KEY
-from langchain.prompts import ChatPromptTemplate
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_google_genai.chat_models import ChatGoogleGenerativeAI
+from langchain_core.messages import HumanMessage
 from langchain_openai.chat_models import ChatOpenAI
 from langsmith import utils
 import logging
@@ -30,12 +32,13 @@ Please keep in mind that, certain functions and methods can only be used on some
 So, knowing the datatype of the columns is really important.
 
 If you dont know the answer, just say you dont know.
+And do not prefix the actual sql query with 'SQL query: ' and try to start the Query right away.
 
 Generate a SQL query to answer this question.
 """)
 
 # Defining the LLM that will be used to answer the user query
-model = ChatOpenAI(openai_api_key = OPENAI_API_KEY, model="gpt-3.5-turbo")
+model = ChatGoogleGenerativeAI(model="gemini-2.5-flash")
 
 # Defining the output parser to parse the output of the LLM and exrtact the content out of the AIMessage object response
 def outputParser(response):

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ langchain==0.3.17
 langchain-community==0.3.16
 langchain-core==0.3.33
 langchain-mongodb==0.4.0
+langchain-aigoogle==0.1.0
 langchain-openai==0.3.3
 langchain-text-splitters==0.3.5
 langgraph==0.2.68


### PR DESCRIPTION
Changes made:
- OpenAI free quota has expired. Hence, Switching to Google gemini.
- Updated the prompt to avoid prefixing the generated SQL query with "SQL Query: "
- Tested the changes thoroughly